### PR TITLE
TravisCI, new Gemfile, refactored Rakefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+Gemfile.lock
 .rake_tasks
 pkg

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+---
+sudo: false
+language: ruby
+cache: bundler
+rvm:
+  - 3.0.0
+  - 2.5.8
+before_install: gem install bundler -v 2.2.10

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,62 +1,10 @@
-require 'rubygems'
-require 'yaml'
-require 'rake'
-
-begin
-  require 'jeweler'
-  Jeweler::Tasks.new do |gem|
-    gem.name = "multipass"
-    gem.summary = 'Bare bones implementation of encoding and decoding MultiPass values for SSO.'
-    gem.email = "technoweenie@gmail.com"
-    gem.homepage = "https://github.com/entp/multipass"
-    gem.authors = ["rick"]
-    gem.add_dependency 'ezcrypto'
-
-    # gem is a Gem::Specification... see http://www.rubygems.org/read/chapter/20 for additional settings
-  end
-rescue LoadError
-  puts "Jeweler not available. Install it with: gem install jeweler"
-end
-
+require 'bundler/gem_tasks'
 require 'rake/testtask'
+
 Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test'
   test.pattern = 'test/**/*_test.rb'
   test.verbose = false
 end
 
-begin
-  require 'rcov/rcovtask'
-  Rcov::RcovTask.new do |test|
-    test.libs << 'test'
-    test.pattern = 'test/**/*_test.rb'
-    test.verbose = true
-  end
-rescue LoadError
-  task :rcov do
-    abort "RCov is not available. In order to run rcov, you must: sudo gem install spicycode-rcov"
-  end
-end
-
-
 task :default => :test
-
-begin
-  require 'rake/rdoctask'
-rescue LoadError
-  require 'rdoc/task'
-end
-Rake::RDocTask.new do |rdoc|
-  if File.exist?('VERSION.yml')
-    config = YAML.load(File.read('VERSION.yml'))
-    version = "#{config[:major]}.#{config[:minor]}.#{config[:patch]}"
-  else
-    version = ""
-  end
-
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title = "multipass #{version}"
-  rdoc.rdoc_files.include('README*')
-  rdoc.rdoc_files.include('lib/**/*.rb')
-end
-

--- a/multipass.gemspec
+++ b/multipass.gemspec
@@ -41,5 +41,9 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<ezcrypto>.freeze, [">= 0"])
   end
+
+  s.add_development_dependency 'bundler', '~> 2.2'
+  s.add_development_dependency 'rake', '~> 13.0'
+  s.add_development_dependency 'test-unit', '~> 3.4'
 end
 


### PR DESCRIPTION
Added TravisCI with configurations for Ruby `2.5.8` and `3.0.0`.
A `Gemfile` has been added along with a `Rakefile` refactoring (removed everything but the test-unit block)